### PR TITLE
bugfix for not throwing error on reading non JSON values from cookies

### DIFF
--- a/src/getStateFromCookies.js
+++ b/src/getStateFromCookies.js
@@ -46,8 +46,8 @@ const getStateFromCookies = (
         if (storedState) {
             try {
                 stateTree[terminalKey] = JSON.parse(storedState);
-            } catch (err) {
-                console.error(`Unable to set state from cookie at ${pathConf.name}. Error: `, err);
+            } catch (_) {
+                stateTree[terminalKey] = storedState;
             }
         }
     });

--- a/test/getStoreFromCookies.spec.js
+++ b/test/getStoreFromCookies.spec.js
@@ -63,4 +63,26 @@ describe('getStateFromCookies', () => {
 
         expect(getCookie).toHaveBeenCalledWith('userId');
     });
+
+    it('should read non JSON values from cookie', () => {
+        jsCookie.set('authToken', authToken);
+        jsCookie.set('userId', userId);
+        jsCookie.set('geolocation', null);
+        const paths = {
+            userId: { name: 'userId' },
+            geolocation: { name: 'geolocation' },
+            'auth.authToken': { name: 'authToken' },
+        };
+        initialState = {
+            userId: null,
+            auth: {
+                authToken: null
+            },
+            geolocation: null
+        };
+        const value = getStateFromCookies(initialState, paths);
+        expect(value.auth.authToken).toEqual(authToken);
+        expect(value.userId).toEqual(userId);
+        expect(value.geolocation).toEqual(null);
+    });
 });


### PR DESCRIPTION
This PR adds the ability to read values as it is from cookies rather than assuming it to be JSON and throwing error otherwise.